### PR TITLE
Suggest labels into bpdocs labels

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -911,3 +911,17 @@ function bp_docs_filter_active_components_unhook() {
 	remove_filter( 'bp_active_components', 'bp_docs_filter_active_components' );
 }
 add_action( 'bp_member_plugin_options_nav', 'bp_docs_filter_active_components_unhook' );
+
+// XTEC ************ AFEGIT ­ Suggest labels into documents - bp-docs
+// 2016.06.23 @xaviernietosanchez
+function add_suggest_script() {
+	wp_enqueue_script( 'jquery' );
+	wp_enqueue_script( 'jquery-ui-autocomplete' );
+	wp_register_style( 'jquery-ui-styles','https://ajax.googleapis.com/ajax/libs/jqueryui/1.8/themes/base/jquery-ui.css' );
+	wp_enqueue_style( 'jquery-ui-styles' );
+	wp_register_script( 'suggest_complete', plugins_url('/js/suggest_complete.js',__FILE__), array( 'jquery', 'jquery-ui-autocomplete' ), '1.0', false );
+	wp_localize_script( 'suggest_complete', 'SuggestComplete', array( 'url' => admin_url( 'admin-ajax.php' ) ) );
+	wp_enqueue_script( 'suggest_complete' );
+}
+add_action( 'wp_enqueue_scripts', 'add_suggest_script' );
+//************ FI

--- a/includes/js/AFEGIT_XTEC
+++ b/includes/js/AFEGIT_XTEC
@@ -1,0 +1,3 @@
+//XTEC ************ FITXER AFEGIT
+
+suggest_complete.js

--- a/includes/js/suggest_complete.js
+++ b/includes/js/suggest_complete.js
@@ -1,0 +1,51 @@
+// XTEC ************ AFEGIT ­ JQuery script to show different options for suggest labels
+// 2016.06.23 @xaviernietosanchez
+(function( $ ) {
+	$(function() {
+		function split( val ) {
+	    	return val.split( /,\s*/ );
+	    }
+	    function extractLast( term ) {
+	    	return split( term ).pop();
+	    }
+
+	    $( "#tax-input-bp_docs_tag" )
+	    	// don't navigate away from the field on tab when selecting an item
+	    	.bind( "keydown", function( event ) {
+	        	if ( event.keyCode === $.ui.keyCode.TAB &&
+	            	$( this ).autocomplete( "instance" ).menu.active ) {
+	          		event.preventDefault();
+	        	}
+	    	})
+	        .autocomplete({
+	        	source: function( request, response ) {
+	          		$.getJSON( SuggestComplete.url + "?action=suggest_label", {
+	            	term: extractLast( request.term )
+	          	}, response );
+	        },
+	        search: function() {
+	          	// custom minLength
+	          	var term = extractLast( this.value );
+	          	if ( term.length < 1 ) {
+	            	return false;
+	          	}
+	        },
+	        focus: function() {
+	          	// prevent value inserted on focus
+	          	return false;
+	        },
+	        select: function( event, ui ) {
+	          	var terms = split( this.value );
+	          	// remove the current input
+	          	terms.pop();
+	          	// add the selected item
+	          	terms.push( ui.item.value );
+	          	// add placeholder to get the comma-and-space at the end
+	          	terms.push( "" );
+	          	this.value = terms.join( ", " );
+	          	return false;
+	        }
+	    });
+	});
+})( jQuery );
+// ************ FI


### PR DESCRIPTION
Implementada la funcionalitat per quan s'afegeixen etiquetes als documents, apareguin suggerències basades en anteriors etiquetes abans introduïdes.

Concretament esta basades en les anteriors etiquetes que assignades a documents.
La suggerència apareix al introduir un primer caràcter al `text-area` d'etiquetes.

Es poden afegir múltiples etiquetes.
