### PR TITLE
Fix upload image to select it when create a new document

### DIFF
--- a/includes/js/attachments.js
+++ b/includes/js/attachments.js
@@ -31,6 +31,10 @@ window.wp = window.wp || {};
 			success: function(s) {
 				$('#doc-attachments-ul').prepend(s.data);
 				file_frame.close();
+				// XTEC ************ AFEGIT ­Fix when attachment image into new document, no show image to select it
+				// 2016.07.05 @xaviernietosanchez
+				change_select_to_show_image();
+				// ************ FI
 			}
 		} );
 	};
@@ -71,4 +75,20 @@ window.wp = window.wp || {};
 
 		Library = file_frame.states.get('library');
 	});
+
+	// XTEC ************ AFEGIT ­Fix when attachment image into new document, no show image to select it
+	// 2016.07.05 @xaviernietosanchez
+	function change_select_to_show_image(id){
+		if ( $('#media-attachment-filters').length > 0 ){
+			if ( $('#media-attachment-filters option:selected').text() == 'Tots els fitxers multimèdia' ){
+				jQuery('#media-attachment-filters>option:eq(1)').attr("selected","selected");
+				jQuery('#media-attachment-filters').trigger("change");
+				if( jQuery('div[class="media-toolbar-primary search-form"]').length > 0 ){
+					jQuery('div[class="media-toolbar-primary search-form"]').find('button').removeClass('button');
+				}
+			}
+		}
+	}
+	// ************ FI
+
 })(jQuery);


### PR DESCRIPTION
- Aplicada una solució en Javascript que detecta quan s'ha pujat una imatge correctament i canvia el Select superior per tal d'actualitzar les imatges.
- Corregit conflicte de classe amb el botó enviar al fer "hover".

Per tal de provar-ho cal crear un document nou amb el bpdocs e intentar inserir una fitxer multimèdia.
Comprovar que una vegada pujat, surt visible i es pot seleccionar.
