### PR TITLE
Default add 'and' to condition, and change text link for correct usability

### DIFF
--- a/includes/addon-taxonomy.php
+++ b/includes/addon-taxonomy.php
@@ -500,6 +500,7 @@ function bp_docs_get_tag_link( $args = array() ) {
 
 // XTEC ************ AFEGIT - Added support for multitag
 // 2016.04.27 @sarjona
+// 2016.10.10 @xaviernietosanchez
 /**
  * Get an archive link for a given tag
  *
@@ -553,6 +554,11 @@ function bp_docs_get_tag_link_multitag( $args = array() ) {
 	}
 	if ( !empty( $_REQUEST['bool'] ) ) {
 		$item_docs_url = add_query_arg( 'bool', $_REQUEST['bool'], $item_docs_url );
+	} else {
+		/*
+		 * If not exist boolean argument, default add "and" condition
+		 */
+		$item_docs_url = add_query_arg( 'bool', 'and', $item_docs_url );
 	}
 	$bdp_tags = implode( ',', array_filter( $bdp_tags ) );
 	$url = apply_filters( 'bp_docs_get_tag_link_url', add_query_arg( 'bpd_tag', $bdp_tags, $item_docs_url ), $args, $item_docs_url );

--- a/includes/templatetags.php
+++ b/includes/templatetags.php
@@ -254,12 +254,13 @@ function bp_docs_info_header() {
 
 			// XTEC ************ AFEGIT - Added support for multitag
 			// 2016.04.27 @sarjona
+			// 2016.10.10 @xaviernietosanchez
 			if ( !empty( $_REQUEST['bool'] ) && $_REQUEST['bool'] === 'and' ) {
 				// AND operator is enabled so show "OR" link
-				$message .= ' - ' . sprintf( __( '<strong><a href="%s" title="View Docs with some of the selected tags">Viewing docs with each of these tags</a></strong>', 'bp-docs' ), add_query_arg( 'bool', 'or' ) );
+				$message .= ' - ' . sprintf( __( '<strong><a href="%s" title="View Docs with some of the selected tags">Viewing docs with some of these tags</a></strong>', 'bp-docs' ), add_query_arg( 'bool', 'or' ) );
 			} else {
 				// OR operator is enabled so show "AND" link
-				$message .= ' - ' . sprintf( __( '<strong><a href="%s" title="View Docs with all selected tags">Viewing docs with some of these tags</a></strong>', 'bp-docs' ), add_query_arg( 'bool', 'and' ) );
+				$message .= ' - ' . sprintf( __( '<strong><a href="%s" title="View Docs with all selected tags">Viewing docs with each of these tags</a></strong>', 'bp-docs' ), add_query_arg( 'bool', 'and' ) );
 			}
 			//************ FI
 			$message .= ' - ' . sprintf( __( '<strong><a href="%s" title="View All Docs">View All Docs</a></strong>', 'bp-docs' ), remove_query_arg( $filter_args ) );

--- a/languages/bp-docs-ca.po
+++ b/languages/bp-docs-ca.po
@@ -1440,11 +1440,11 @@ msgstr "http://boone.gorg.es"
 
 # AFEGIT XTEC
 msgid ""
-"<strong><a href=\"%s\" title=\"View Docs with all selected tags\">Viewing docs with some of these tags</a></strong>"
+"<strong><a href=\"%s\" title=\"View Docs with some of the selected tags\">Viewing docs with some of these tags</a></strong>"
 msgstr "<strong><a href=\"%s\" title=\"Visualitza documents amb totes les etiquetes seleccionades\">Documents amb alguna etiqueta</a></strong>"
 
 # AFEGIT XTEC
 msgid ""
-"<strong><a href=\"%s\" title=\"View Docs with some of the selected tags\">Viewing docs with each of these tags</a></strong>"
+"<strong><a href=\"%s\" title=\"View Docs with all selected tags\">Viewing docs with each of these tags</a></strong>"
 msgstr ""
 "<strong><a href=\"%s\" title=\"Visualitza documents amb alguna de les etiquetes seleccionades\">Documents amb totes les etiquetes</a></strong>"


### PR DESCRIPTION
Modificada la funcionalitat perquè per defecte quan cerquem a través d'etiquetes, les etiquetes sigui amb una condició 'AND' (mostrarà els documents que tinguin totes aquestes etiquetes), enlloc de mostrar els documents que tenen alguna de les etiquetes.

També modificat l'enllça per canviar la funcionalitat, per la seva opció contraria.

Proves:
- Cal accedir a un node | documents, que tingui documents amb etiquetes asignades.
- Cercar per etiquetes, i anar escollint etiquetes, veure com es comporta per defecte.
- Fixar-se en el text de l'enllaç justament a sobre, per veure que porta com a text l'opció justament diferent a la que es troba activada.
